### PR TITLE
Added rocon_concert sources (indigo)

### DIFF
--- a/workspace/rocon_web_proxy.rosinstall
+++ b/workspace/rocon_web_proxy.rosinstall
@@ -2,6 +2,10 @@
 #       http://ros.org/wiki/rocon_tools/Tutorials/indigo/Installation
 #
 [
+
+# Stacks necessary for rocon concert managment
+{'git': {'local-name': 'rocon_concert', 'version': 'indigo', 'uri': 'https://github.com/robotics-in-concert/rocon_concert.git'}},
+
 # Stacks necessary for rocon tools
 {'git': {'local-name': 'rocon_msgs', 'version': 'indigo', 'uri': 'https://github.com/robotics-in-concert/rocon_msgs.git'}},
 {'git': {'local-name': 'unique_identifier', 'version': 'master', 'uri': 'https://github.com/ros-geographic-info/unique_identifier.git'}},


### PR DESCRIPTION
This is needed to correspond with latest changes in rocon_tools indigo, otherwise it won't work from sources.
cc: @adamantivm That's the error I was having yesterday, although it raises other error (fatal one: just a few lines red in the concert terminal):
`unused args [auto_enable_services] for include of [/home/ivan/src/rocon_web_proxy_files/workspace/src/rocon_concert/concert_master/launch/concert_master.launch]`
